### PR TITLE
fix BuildHandle helper

### DIFF
--- a/tc.go
+++ b/tc.go
@@ -223,7 +223,7 @@ type Attribute struct {
 
 // BuildHandle is a simple helper function to construct the handle for the Tcmsg struct
 func BuildHandle(maj, min uint32) uint32 {
-	return ((maj & handleMajMask) | (min & handleMinMask))
+	return (((maj << 16) & handleMajMask) | (min & handleMinMask))
 }
 
 // XStats contains further statistics to the TCA_KIND

--- a/tc_test.go
+++ b/tc_test.go
@@ -147,3 +147,28 @@ func TestMonitor(t *testing.T) {
 
 	<-ctx.Done()
 }
+
+// Test the BuildHandleFunction
+func TestBuildHandle(t *testing.T) {
+	type args struct {
+		maj uint32
+		min uint32
+	}
+	tests := []struct {
+		name string
+		args args
+		want uint32
+	}{
+		{"0:2", args{0, 2}, 2},
+		{"0:65535", args{0, 65535}, 0x0000ffff},
+		{"65535:65535", args{65535, 65535}, 0xffffffff},
+		{"65535:65535", args{65535, 0}, 0xffff0000},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := BuildHandle(tt.args.maj, tt.args.min); got != tt.want {
+				t.Errorf("BuildHandle() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The BuildHandle function was incorrectly converting the major and minor
part of the handle. The arguments `1:10` would output the handle `10`
while it should have been `65546`.

This is fixed by left shifting the major part 16 bits.