### PR TITLE
Add tests for HfscQOpt marshal and unmarshal function

### DIFF
--- a/q_hfsc_test.go
+++ b/q_hfsc_test.go
@@ -48,3 +48,39 @@ func TestHfsc(t *testing.T) {
 		}
 	})
 }
+
+func TestHfscQOpt(t *testing.T) {
+	tests := map[string]struct {
+		val  HfscQOpt
+		err1 error
+		err2 error
+	}{
+		"defcls 1":      {val: HfscQOpt{DefCls: 1}},
+		"defcls 0":      {val: HfscQOpt{DefCls: 0}},
+		"defcls 0xffff": {val: HfscQOpt{DefCls: 0xffff}},
+	}
+
+	for name, testcase := range tests {
+		t.Run(name, func(t *testing.T) {
+			data, err1 := marshalHfscQOpt(&testcase.val)
+			if err1 != nil {
+				t.Fatalf("unexpected error: %v", err1)
+			}
+			val := HfscQOpt{}
+			err2 := unmarshalHfscQOpt(data, &val)
+			if err2 != nil {
+				t.Fatalf("unexpected error: %v", err2)
+			}
+			if diff := cmp.Diff(val, testcase.val); diff != "" {
+				t.Fatalf("HfscQOpt mismiatch (want+got):\n%s", diff)
+			}
+		})
+	}
+
+	t.Run("nil", func(t *testing.T) {
+		_, err := marshalHfscQOpt(nil)
+		if !errors.Is(err, nil) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
There were no tests present for testing the HfscQOpt marshal and unmarshal function.