### PR TITLE
Endian fix for KeyVlanID and KeyCVlanID

### DIFF
--- a/f_flower.go
+++ b/f_flower.go
@@ -437,7 +437,7 @@ func marshalFlower(info *Flower) ([]byte, error) {
 		options = append(options, tcOption{Interpretation: vtUint16Be, Type: tcaFlowerKeyUDPDst, Data: *info.KeyUDPDst})
 	}
 	if info.KeyVlanID != nil {
-		options = append(options, tcOption{Interpretation: vtUint16Be, Type: tcaFlowerKeyVlanID, Data: *info.KeyVlanID})
+		options = append(options, tcOption{Interpretation: vtUint16, Type: tcaFlowerKeyVlanID, Data: *info.KeyVlanID})
 	}
 	if info.KeyVlanPrio != nil {
 		options = append(options, tcOption{Interpretation: vtUint8, Type: tcaFlowerKeyVlanPrio, Data: *info.KeyVlanPrio})
@@ -579,7 +579,7 @@ func marshalFlower(info *Flower) ([]byte, error) {
 		options = append(options, tcOption{Interpretation: vtUint8, Type: tcaFlowerKeyIPTTLMask, Data: *info.KeyIPTTLMask})
 	}
 	if info.KeyCVlanID != nil {
-		options = append(options, tcOption{Interpretation: vtUint16Be, Type: tcaFlowerKeyCVlanID, Data: *info.KeyCVlanID})
+		options = append(options, tcOption{Interpretation: vtUint16, Type: tcaFlowerKeyCVlanID, Data: *info.KeyCVlanID})
 	}
 	if info.KeyCVlanPrio != nil {
 		options = append(options, tcOption{Interpretation: vtUint8, Type: tcaFlowerKeyCVlanPrio, Data: *info.KeyCVlanPrio})

--- a/f_flower_test.go
+++ b/f_flower_test.go
@@ -95,7 +95,6 @@ func TestFlower(t *testing.T) {
 	endianessMix[tcaFlowerKeyTCPDst] = vtUint16Be
 	endianessMix[tcaFlowerKeyUDPSrc] = vtUint16Be
 	endianessMix[tcaFlowerKeyUDPDst] = vtUint16Be
-	endianessMix[tcaFlowerKeyVlanID] = vtUint16Be
 	endianessMix[tcaFlowerKeyVlanEthType] = vtUint16Be
 	endianessMix[tcaFlowerKeyEncKeyID] = vtUint32Be
 	endianessMix[tcaFlowerKeyEncIPv4Src] = vtUint32Be
@@ -122,7 +121,6 @@ func TestFlower(t *testing.T) {
 	endianessMix[tcaFlowerKeyArpTIPMask] = vtUint32Be
 	endianessMix[tcaFlowerKeyTCPFlags] = vtUint16Be
 	endianessMix[tcaFlowerKeyTCPFlagsMask] = vtUint16Be
-	endianessMix[tcaFlowerKeyCVlanID] = vtUint16Be
 	endianessMix[tcaFlowerKeyCVlanEthType] = vtUint16Be
 
 	for name, testcase := range tests {


### PR DESCRIPTION
I noticed that these particular keys had the same endianness problem we were seeing a few days ago. I tested that this change was correct with `tc -s`. 