### PR TITLE
add ability to set netlink conn options

### DIFF
--- a/tc.go
+++ b/tc.go
@@ -43,6 +43,14 @@ func Open(config *Config) (*Tc, error) {
 	return &tc, nil
 }
 
+func (tc *Tc) SetOption(o netlink.ConnOption, enable bool) error {
+	err := tc.con.SetOption(o, enable)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // Close the connection
 func (tc *Tc) Close() error {
 	return tc.con.Close()


### PR DESCRIPTION
The netlink library supports several [ConnOptions](https://github.com/mdlayher/netlink/blob/main/conn.go#L407) that can come in quite handy. I've maintained a personal branch for a while that I use to enable the `ExtendedAcknowledge`.

I'm opening this PR to see if there's an interest in getting this functionality included. If there is, I'm open to extend the testing to include this functionality.