### PR TITLE
monitor: add context stop to return from Go routine

### DIFF
--- a/tc.go
+++ b/tc.go
@@ -350,6 +350,9 @@ func (tc *Tc) monitor(ctx context.Context, deadline time.Duration,
 				if ret := errfn(err); ret != 0 {
 					return
 				}
+				if ctx.Err() != nil {
+					return
+				}
 				continue
 			}
 			for _, msg := range msgs {


### PR DESCRIPTION
If ErrorFunc always returns 0 it can happen that the listening Go routine never stops.