### PR TITLE
fix ematch container parse

### DIFF
--- a/ematch_container.go
+++ b/ematch_container.go
@@ -1,5 +1,6 @@
 package tc
 
+// ContainerMatch contains attributes of the container match discipline
 type ContainerMatch struct {
 	Pos uint32
 }

--- a/ematch_container.go
+++ b/ematch_container.go
@@ -1,0 +1,31 @@
+package tc
+
+type ContainerMatch struct {
+	Pos uint32
+}
+
+func unmarshalContainerMatch(data []byte, info *ContainerMatch) error {
+	if info == nil {
+		return ErrNoArg
+	}
+
+	tmp := ContainerMatch{}
+	if err := unmarshalStruct(data, &tmp); err != nil {
+		return err
+	}
+
+	info.Pos = tmp.Pos
+	return nil
+}
+
+func marshalContainerMatch(info *ContainerMatch) ([]byte, error) {
+	if info == nil {
+		return []byte{}, ErrNoArg
+	}
+
+	if info.Pos == 0 {
+		return nil, ErrInvalidArg
+	}
+
+	return marshalStruct(info)
+}

--- a/ematch_container_test.go
+++ b/ematch_container_test.go
@@ -1,0 +1,67 @@
+package tc
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestContainerMatch(t *testing.T) {
+	tests := map[string]uint32{
+		"TestPos5":   uint32(5),
+		"TestPos100": uint32(100),
+	}
+	for name, pos := range tests {
+		t.Run(name, func(t *testing.T) {
+			in := ContainerMatch{
+				Pos: pos,
+			}
+
+			data, err := marshalContainerMatch(&in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			out := ContainerMatch{}
+			if err := unmarshalContainerMatch(data, &out); err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(in, out); diff != "" {
+				t.Fatalf("ContainerMatch missmatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+
+	t.Run("invalid pos", func(t *testing.T) {
+		in := ContainerMatch{
+			Pos: 0,
+		}
+		if _, err := marshalContainerMatch(&in); !errors.Is(err, ErrInvalidArg) {
+			t.Fatalf("Expected ErrInvalidArg but got '%v'", err)
+		}
+	})
+	t.Run("nil-marshalContainerMatch", func(t *testing.T) {
+		_, err := marshalContainerMatch(nil)
+		if !errors.Is(err, ErrNoArg) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("nil-unmarshalContainerMatch", func(t *testing.T) {
+		inByte := []byte{0x0001}
+
+		if err := unmarshalContainerMatch(inByte, nil); !errors.Is(err, ErrNoArg) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("nil-byte-unmarshalContainerMatch", func(t *testing.T) {
+		out := ContainerMatch{
+			Pos: 10,
+		}
+		if err := unmarshalContainerMatch([]byte{}, &out); !errors.Is(err, io.EOF) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}

--- a/ematch_ipset.go
+++ b/ematch_ipset.go
@@ -47,7 +47,7 @@ func marshalIPSetMatch(info *IPSetMatch) ([]byte, error) {
 		ID: info.IPSetID,
 	}
 
-	if len(info.Dir) == 0 || len(info.Dir) > 2 {
+	if len(info.Dir) == 0 || len(info.Dir) > 3 {
 		return nil, ErrInvalidArg
 	}
 

--- a/ematch_test.go
+++ b/ematch_test.go
@@ -81,6 +81,53 @@ func TestEmatch(t *testing.T) {
 				},
 			},
 		},
+
+		// A AND (B1 OR B2) AND NOT C
+		// EmatchHMatch:
+		//   ----------------------------
+		//   |  A | (  | C  | B1  | B2)  |
+		//   -----------------------------
+		"match 'ipset(A src,src)' and  (ipset(B1 dst,dst) or ipset(B2 src,dst,dst)) and not ipset(C src,dst)) ": {
+			val: Ematch{
+				Hdr: &EmatchTreeHdr{NMatches: 5},
+				Matches: &[]EmatchMatch{
+					{
+						Hdr: EmatchHdr{MatchID: 0, Kind: EmatchIPSet, Flags: TCF_EM_REL_AND, Pad: 0x0},
+						IPSetMatch: &IPSetMatch{
+							IPSetID: 10, // IpsetName : A
+							Dir:     []IPSetDir{IPSetSrc, IPSetSrc},
+						},
+					},
+					{
+						Hdr: EmatchHdr{MatchID: 0, Kind: EmatchContainer, Flags: TCF_EM_REL_AND, Pad: 0x0},
+						ContainerMatch: &ContainerMatch{
+							Pos: 3,
+						},
+					},
+					{
+						Hdr: EmatchHdr{MatchID: 0, Kind: EmatchIPSet, Flags: TCF_EM_INVERT, Pad: 0x0},
+						IPSetMatch: &IPSetMatch{
+							IPSetID: 13, // IpsetName : C
+							Dir:     []IPSetDir{IPSetSrc, IPSetDst},
+						},
+					},
+					{
+						Hdr: EmatchHdr{MatchID: 0, Kind: EmatchIPSet, Flags: TCF_EM_REL_OR, Pad: 0x0},
+						IPSetMatch: &IPSetMatch{
+							IPSetID: 11, // IpsetName : B1
+							Dir:     []IPSetDir{IPSetDst, IPSetDst},
+						},
+					},
+					{
+						Hdr: EmatchHdr{MatchID: 0, Kind: EmatchIPSet, Flags: TCF_EM_REL_END, Pad: 0x0},
+						IPSetMatch: &IPSetMatch{
+							IPSetID: 12, // IpsetName : B2
+							Dir:     []IPSetDir{IPSetSrc, IPSetDst, IPSetDst},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for name, testcase := range tests {

--- a/ematch_test.go
+++ b/ematch_test.go
@@ -30,7 +30,7 @@ func TestEmatch(t *testing.T) {
 				Hdr: &EmatchTreeHdr{NMatches: 2},
 				Matches: &[]EmatchMatch{
 					{
-						Hdr: EmatchHdr{MatchID: 0x0, Kind: EmatchU32, Flags: 0x1, Pad: 0x0},
+						Hdr: EmatchHdr{MatchID: 0x0, Kind: EmatchU32, Flags: EmatchRelAnd, Pad: 0x0},
 						U32Match: &U32Match{
 							Mask:    0xffff,
 							Value:   0x1122,
@@ -39,7 +39,7 @@ func TestEmatch(t *testing.T) {
 						},
 					},
 					{
-						Hdr: EmatchHdr{MatchID: 0x0, Kind: EmatchCmp, Flags: 0x0, Pad: 0x0},
+						Hdr: EmatchHdr{MatchID: 0x0, Kind: EmatchCmp, Flags: EmatchRelEnd, Pad: 0x0},
 						CmpMatch: &CmpMatch{
 							Val:   0x14,
 							Mask:  0xff00,
@@ -58,7 +58,7 @@ func TestEmatch(t *testing.T) {
 				Hdr: &EmatchTreeHdr{NMatches: 1, ProgID: 42},
 				Matches: &[]EmatchMatch{
 					{
-						Hdr: EmatchHdr{MatchID: 0, Kind: EmatchIPSet, Flags: 0x0, Pad: 0x0},
+						Hdr: EmatchHdr{MatchID: 0, Kind: EmatchIPSet, Flags: EmatchRelEnd, Pad: 0x0},
 						IPSetMatch: &IPSetMatch{
 							IPSetID: 19,
 							Dir:     []IPSetDir{IPSetSrc, IPSetSrc},
@@ -72,7 +72,7 @@ func TestEmatch(t *testing.T) {
 				Hdr: &EmatchTreeHdr{NMatches: 1, ProgID: 42},
 				Matches: &[]EmatchMatch{
 					{
-						Hdr: EmatchHdr{MatchID: 0, Kind: 0x9, Flags: 0x0, Pad: 0x0},
+						Hdr: EmatchHdr{MatchID: 0, Kind: 0x9, Flags: EmatchRelEnd, Pad: 0x0},
 						IptMatch: &IptMatch{
 							MatchName: stringPtr("foobar"),
 							NFProto:   uint8Ptr(10),
@@ -92,34 +92,34 @@ func TestEmatch(t *testing.T) {
 				Hdr: &EmatchTreeHdr{NMatches: 5},
 				Matches: &[]EmatchMatch{
 					{
-						Hdr: EmatchHdr{MatchID: 0, Kind: EmatchIPSet, Flags: TCF_EM_REL_AND, Pad: 0x0},
+						Hdr: EmatchHdr{MatchID: 0, Kind: EmatchIPSet, Flags: EmatchRelAnd, Pad: 0x0},
 						IPSetMatch: &IPSetMatch{
 							IPSetID: 10, // IpsetName : A
 							Dir:     []IPSetDir{IPSetSrc, IPSetSrc},
 						},
 					},
 					{
-						Hdr: EmatchHdr{MatchID: 0, Kind: EmatchContainer, Flags: TCF_EM_REL_AND, Pad: 0x0},
+						Hdr: EmatchHdr{MatchID: 0, Kind: EmatchContainer, Flags: EmatchRelAnd, Pad: 0x0},
 						ContainerMatch: &ContainerMatch{
 							Pos: 3,
 						},
 					},
 					{
-						Hdr: EmatchHdr{MatchID: 0, Kind: EmatchIPSet, Flags: TCF_EM_INVERT, Pad: 0x0},
+						Hdr: EmatchHdr{MatchID: 0, Kind: EmatchIPSet, Flags: EmatchInvert, Pad: 0x0},
 						IPSetMatch: &IPSetMatch{
 							IPSetID: 13, // IpsetName : C
 							Dir:     []IPSetDir{IPSetSrc, IPSetDst},
 						},
 					},
 					{
-						Hdr: EmatchHdr{MatchID: 0, Kind: EmatchIPSet, Flags: TCF_EM_REL_OR, Pad: 0x0},
+						Hdr: EmatchHdr{MatchID: 0, Kind: EmatchIPSet, Flags: EmatchRelOr, Pad: 0x0},
 						IPSetMatch: &IPSetMatch{
 							IPSetID: 11, // IpsetName : B1
 							Dir:     []IPSetDir{IPSetDst, IPSetDst},
 						},
 					},
 					{
-						Hdr: EmatchHdr{MatchID: 0, Kind: EmatchIPSet, Flags: TCF_EM_REL_END, Pad: 0x0},
+						Hdr: EmatchHdr{MatchID: 0, Kind: EmatchIPSet, Flags: EmatchRelEnd, Pad: 0x0},
 						IPSetMatch: &IPSetMatch{
 							IPSetID: 12, // IpsetName : B2
 							Dir:     []IPSetDir{IPSetSrc, IPSetDst, IPSetDst},


### PR DESCRIPTION
1, ipset dir len Maxlen is 3, example "ip,port,ip"。
 2, add ematch container kind, In order to accomplish complex logical combinations。 example: A and(B1 or B2)