### PR TITLE
adding support for prngseed

### DIFF
--- a/q_netem.go
+++ b/q_netem.go
@@ -23,6 +23,7 @@ const (
 	tcaNetemJitter64
 	tcaNetemSlot
 	tcaNetemSlotDist
+	tcaNetemPrngSeed
 )
 
 // Netem contains attributes of the netem discipline
@@ -38,6 +39,7 @@ type Netem struct {
 	Latency64 *int64
 	Jitter64  *int64
 	Slot      *NetemSlot
+	PrngSeed  *uint64
 }
 
 // NetemQopt from include/uapi/linux/pkt_sched.h
@@ -153,6 +155,9 @@ func unmarshalNetem(data []byte, info *Netem) error {
 			info.Slot = tmp
 		case tcaNetemPad:
 			// padding does not contain data, we just skip it
+		case tcaNetemPrngSeed:
+			tmp := ad.Uint64()
+			info.PrngSeed = &tmp
 		default:
 			return fmt.Errorf("unmarshalNetem()\t%d\n\t%v", ad.Type(), ad.Bytes())
 		}
@@ -210,6 +215,9 @@ func marshalNetem(info *Netem) ([]byte, error) {
 		data, err := marshalStruct(info.Slot)
 		multiError = concatError(multiError, err)
 		options = append(options, tcOption{Interpretation: vtBytes, Type: tcaNetemSlot, Data: data})
+	}
+	if info.PrngSeed !=nil {
+		options = append(options, tcOption{Interpretation: vtUint64, Type: tcaNetemPrngSeed, Data: *info.PrngSeed})
 	}
 
 	data, err := marshalAttributes(options)

--- a/q_netem_test.go
+++ b/q_netem_test.go
@@ -22,9 +22,10 @@ func TestNetem(t *testing.T) {
 				Jitter:  core.Time2Tick(3),
 			},
 			DelayDist: &delayDist}},
-		"simple": {val: Netem{Ecn: uint32Ptr(123), Latency64: int64Ptr(-4242), Jitter64: int64Ptr(-1337)}},
-		"qopt":   {val: Netem{Qopt: NetemQopt{Latency: 42}, Rate64: uint64Ptr(1337)}},
-		"random": {val: Netem{Corr: &NetemCorr{Delay: 2}, Reorder: &NetemReorder{Correlation: 13}, Corrupt: &NetemCorrupt{Correlation: 11}, Rate: &NetemRate{PacketOverhead: 1337}, Slot: &NetemSlot{MinDelay: 2, MaxDelay: 4}}},
+		"simple":   {val: Netem{Ecn: uint32Ptr(123), Latency64: int64Ptr(-4242), Jitter64: int64Ptr(-1337)}},
+		"qopt":     {val: Netem{Qopt: NetemQopt{Latency: 42}, Rate64: uint64Ptr(1337)}},
+		"random":   {val: Netem{Corr: &NetemCorr{Delay: 2}, Reorder: &NetemReorder{Correlation: 13}, Corrupt: &NetemCorrupt{Correlation: 11}, Rate: &NetemRate{PacketOverhead: 1337}, Slot: &NetemSlot{MinDelay: 2, MaxDelay: 4}}},
+		"prngseed":     {val: Netem{Qopt: NetemQopt{Latency: 42}, Rate64: uint64Ptr(1337), PrngSeed: uint64Ptr(31337)}},
 	}
 
 	for name, testcase := range tests {


### PR DESCRIPTION
Testing with latest Kali VM. Running a `6.6.9` kernel. It complained:
```
2024/07/24 08:33:00 Failed to get initial list: failed to get qdiscs: unmarshalNetem()  14
        [14 54 41 156 178 155 154 90]
```

New type:
https://elixir.bootlin.com/linux/v6.6.9/source/include/uapi/linux/pkt_sched.h#L606

It's a uint64:
https://elixir.bootlin.com/linux/v6.6.9/source/net/sched/sch_netem.c#L933

Added support