### PR TITLE
Fix: validateClassObject for deleting class

### DIFF
--- a/class.go
+++ b/class.go
@@ -80,15 +80,19 @@ func validateClassObject(action int, info *Object) ([]tcOption, error) {
 	case "dsmark":
 		data, err = marshalDsmark(info.Dsmark)
 	default:
-		return options, fmt.Errorf("%s: %w", info.Kind, ErrNotImplemented)
+		if !isDelAction(action) {
+			return options, fmt.Errorf("%s: %w", info.Kind, ErrNotImplemented)
+		}
 	}
 	if err != nil {
 		return options, err
 	}
-	if len(data) < 1 {
+	if len(data) < 1 && !isDelAction(action) {
 		return options, ErrNoArg
 	}
 	options = append(options, tcOption{Interpretation: vtBytes, Type: tcaOptions, Data: data})
-	options = append(options, tcOption{Interpretation: vtString, Type: tcaKind, Data: info.Kind})
+	if !isDelAction(action) {
+		options = append(options, tcOption{Interpretation: vtString, Type: tcaKind, Data: info.Kind})
+	}
 	return options, nil
 }


### PR DESCRIPTION
Class Delete operation does not require info.Kind and data. Skipping this check and append in case action is RTM_DELTCLASS.