### PR TITLE
Fix adding DRR qdisc with empty parameters

### DIFF
--- a/qdisc.go
+++ b/qdisc.go
@@ -158,7 +158,10 @@ func validateQdiscObject(action int, info *Object) ([]tcOption, error) {
 		return options, err
 	}
 	if len(data) < 1 && action == unix.RTM_NEWQDISC {
-		if info.Kind != "clsact" && info.Kind != "ingress" && info.Kind != "qfq" {
+		switch info.Kind {
+		case "clsact", "drr", "ingress", "qfq":
+			// these can be parameterless
+		default:
 			return options, ErrNoArg
 		}
 	} else {

--- a/qdisc_test.go
+++ b/qdisc_test.go
@@ -40,6 +40,7 @@ func TestQdisc(t *testing.T) {
 		cbq     *Cbq
 		cbs     *Cbs
 		codel   *Codel
+		drr     *Drr
 		hhf     *Hhf
 		pie     *Pie
 		choke   *Choke
@@ -71,6 +72,8 @@ func TestQdisc(t *testing.T) {
 			Target: uint32Ptr(1), Limit: uint32Ptr(2), Interval: uint32Ptr(3),
 			ECN: uint32Ptr(4), CEThreshold: uint32Ptr(5),
 		}},
+		"drr":      {kind: "drr", drr: &Drr{Quantum: uint32Ptr(10)}},
+		"emptyDrr": {kind: "drr", drr: &Drr{}},
 		"hhf": {kind: "hhf", hhf: &Hhf{
 			BacklogLimit: uint32Ptr(1), Quantum: uint32Ptr(2), HHFlowsLimit: uint32Ptr(3),
 			ResetTimeout: uint32Ptr(4), AdmitBytes: uint32Ptr(5), EVICTTimeout: uint32Ptr(6), NonHHWeight: uint32Ptr(7),
@@ -115,6 +118,7 @@ func TestQdisc(t *testing.T) {
 					Sfq:     testcase.sfq,
 					Cbq:     testcase.cbq,
 					Codel:   testcase.codel,
+					Drr:     testcase.drr,
 					Hhf:     testcase.hhf,
 					Pie:     testcase.pie,
 					Choke:   testcase.choke,


### PR DESCRIPTION
If not sent, the quantum parameter is set by default by the kernel[^1]. By the way, use a switch statement for better readability and add tests for DRR qdisc, both with and without parameters.

[^1]: https://elixir.bootlin.com/linux/v6.16/source/net/sched/sch_drr.c#L79-L87
