### PR TITLE
Feat/pedit helper methods

### DIFF
--- a/m_action.go
+++ b/m_action.go
@@ -75,6 +75,7 @@ type Action struct {
 	MPLS      *MPLS
 	SkbEdit   *SkbEdit
 	SkbMod    *SkbMod
+	Pedit     *Pedit
 }
 
 func unmarshalActions(data []byte, actions *[]*Action) error {
@@ -211,6 +212,8 @@ func marshalAction(cmd int, info *Action, actOption uint16) ([]byte, error) {
 		data, err = marshalSkbEdit(info.SkbEdit)
 	case "skbmod":
 		data, err = marshalSkbMod(info.SkbMod)
+	case "pedit":
+		data, err = marshalPedit(info.Pedit)
 	default:
 		return []byte{}, fmt.Errorf("unknown kind '%s'", info.Kind)
 	}
@@ -320,6 +323,10 @@ func extractActOptions(data []byte, act *Action, kind string) error {
 		info := &SkbMod{}
 		err = unmarshalSkbMod(data, info)
 		act.SkbMod = info
+	case "pedit":
+		info := &Pedit{}
+		err = unmarshalPedit(data, info)
+		act.Pedit = info
 	default:
 		return fmt.Errorf("extractActOptions(): unsupported kind: %s", kind)
 

--- a/m_pedit.go
+++ b/m_pedit.go
@@ -1,0 +1,278 @@
+package tc
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+
+	"github.com/mdlayher/netlink"
+)
+
+const (
+	peditIPProtoTCP = 6
+	peditIPProtoUDP = 17
+)
+
+const (
+	tcaPeditUnspec = iota
+	tcaPeditTm
+	tcaPeditParms
+	tcaPeditPad
+	tcaPeditParmsEx
+	tcaPeditKeysEx
+	tcaPeditKeyEx
+)
+
+const (
+	tcaPeditKeyExHType = 1
+	tcaPeditKeyExCmd   = 2
+)
+
+type PeditHeaderType uint16
+
+const (
+	PeditHeaderTypeNetwork PeditHeaderType = iota
+	PeditHeaderTypeEth
+	PeditHeaderTypeIP4
+	PeditHeaderTypeIP6
+	PeditHeaderTypeTCP
+	PeditHeaderTypeUDP
+)
+
+type PeditCmd uint16
+
+const (
+	PeditCmdSet PeditCmd = iota
+	PeditCmdAdd
+)
+
+// Pedit contains attributes of the pedit action.
+type Pedit struct {
+	Sel    PeditSel
+	Keys   []PeditKey
+	KeysEx []PeditKeyEx
+	Tm     *Tcft
+}
+
+type PeditSel struct {
+	Index   uint32
+	Capab   uint32
+	Action  int32
+	RefCnt  int32
+	BindCnt int32
+	NKeys   uint8
+	Flags   uint8
+	Pad     [2]byte
+}
+
+type PeditKey struct {
+	Mask    uint32
+	Val     uint32
+	Off     uint32
+	At      uint32
+	OffMask uint32
+	Shift   uint32
+}
+
+type PeditKeyEx struct {
+	HeaderType PeditHeaderType
+	Cmd        PeditCmd
+}
+
+func (p *Pedit) SetEthDst(mac net.HardwareAddr) {
+	if len(mac) < 6 {
+		return
+	}
+	p.addKey(PeditKey{Val: nativeEndian.Uint32(mac[:4])}, PeditHeaderTypeEth, PeditCmdSet)
+	p.addKey(PeditKey{
+		Val:  uint32(nativeEndian.Uint16(mac[4:])),
+		Mask: 0xffff0000,
+		Off:  4,
+	}, PeditHeaderTypeEth, PeditCmdSet)
+}
+
+func (p *Pedit) SetEthSrc(mac net.HardwareAddr) {
+	if len(mac) < 6 {
+		return
+	}
+	p.addKey(PeditKey{
+		Val:  uint32(nativeEndian.Uint16(mac[:2])) << 16,
+		Mask: 0x0000ffff,
+		Off:  4,
+	}, PeditHeaderTypeEth, PeditCmdSet)
+	p.addKey(PeditKey{
+		Val: nativeEndian.Uint32(mac[2:]),
+		Off: 8,
+	}, PeditHeaderTypeEth, PeditCmdSet)
+}
+
+func (p *Pedit) SetIPv4Src(ip net.IP) {
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return
+	}
+	p.addKey(PeditKey{
+		Val: nativeEndian.Uint32(ip4),
+		Off: 12,
+	}, PeditHeaderTypeIP4, PeditCmdSet)
+}
+
+func (p *Pedit) SetIPv4Dst(ip net.IP) {
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return
+	}
+	p.addKey(PeditKey{
+		Val: nativeEndian.Uint32(ip4),
+		Off: 16,
+	}, PeditHeaderTypeIP4, PeditCmdSet)
+}
+
+func (p *Pedit) SetUDPSrc(port uint16) {
+	p.SetSrcPort(port, peditIPProtoUDP)
+}
+
+func (p *Pedit) SetUDPDst(port uint16) {
+	p.SetDstPort(port, peditIPProtoUDP)
+}
+
+func (p *Pedit) SetSrcPort(port uint16, protocol uint8) {
+	headerType, ok := peditProtocolHeaderType(protocol)
+	if !ok {
+		return
+	}
+	p.addKey(PeditKey{
+		Val:  uint32(peditSwap16(port)),
+		Mask: 0xffff0000,
+	}, headerType, PeditCmdSet)
+}
+
+func (p *Pedit) SetDstPort(port uint16, protocol uint8) {
+	headerType, ok := peditProtocolHeaderType(protocol)
+	if !ok {
+		return
+	}
+	p.addKey(PeditKey{
+		Val:  uint32(peditSwap16(port)) << 16,
+		Mask: 0x0000ffff,
+	}, headerType, PeditCmdSet)
+}
+
+func (p *Pedit) AddIPv4TTL(delta uint8) {
+	p.addKey(PeditKey{
+		Val:  uint32(delta),
+		Mask: 0xffffff00,
+		Off:  8,
+	}, PeditHeaderTypeIP4, PeditCmdAdd)
+}
+
+func (p *Pedit) addKey(key PeditKey, headerType PeditHeaderType, cmd PeditCmd) {
+	p.Keys = append(p.Keys, key)
+	p.KeysEx = append(p.KeysEx, PeditKeyEx{HeaderType: headerType, Cmd: cmd})
+	p.Sel.NKeys = uint8(len(p.Keys))
+}
+
+func peditProtocolHeaderType(protocol uint8) (PeditHeaderType, bool) {
+	switch protocol {
+	case peditIPProtoTCP:
+		return PeditHeaderTypeTCP, true
+	case peditIPProtoUDP:
+		return PeditHeaderTypeUDP, true
+	default:
+		return PeditHeaderTypeNetwork, false
+	}
+}
+
+func peditSwap16(v uint16) uint16 {
+	return (v << 8) | (v >> 8)
+}
+
+func marshalPedit(info *Pedit) ([]byte, error) {
+	options := []tcOption{}
+	if info == nil {
+		return []byte{}, fmt.Errorf("Pedit: %w", ErrNoArg)
+	}
+	if info.Tm != nil {
+		return []byte{}, ErrNoArgAlter
+	}
+	if len(info.Keys) != len(info.KeysEx) {
+		return []byte{}, fmt.Errorf("pedit keys and extended keys length mismatch")
+	}
+	if len(info.Keys) > 255 {
+		return []byte{}, fmt.Errorf("pedit supports at most 255 keys")
+	}
+
+	sel := info.Sel
+	sel.NKeys = uint8(len(info.Keys))
+	parms, err := marshalStruct(&sel)
+	if err != nil {
+		return []byte{}, err
+	}
+	buf := bytes.NewBuffer(parms)
+	for i := range info.Keys {
+		keyData, err := marshalStruct(&info.Keys[i])
+		if err != nil {
+			return []byte{}, err
+		}
+		buf.Write(keyData)
+	}
+	options = append(options, tcOption{Interpretation: vtBytes, Type: tcaPeditParmsEx, Data: buf.Bytes()})
+
+	keyOptions := make([]tcOption, 0, len(info.KeysEx))
+	for i := range info.KeysEx {
+		keyExData, err := marshalAttributes([]tcOption{
+			{Interpretation: vtUint16, Type: tcaPeditKeyExHType, Data: uint16(info.KeysEx[i].HeaderType)},
+			{Interpretation: vtUint16, Type: tcaPeditKeyExCmd, Data: uint16(info.KeysEx[i].Cmd)},
+		})
+		if err != nil {
+			return []byte{}, err
+		}
+		keyOptions = append(keyOptions, tcOption{Interpretation: vtBytes, Type: tcaPeditKeyEx | nlaFNnested, Data: keyExData})
+	}
+	keysExData, err := marshalAttributes(keyOptions)
+	if err != nil {
+		return []byte{}, err
+	}
+	options = append(options, tcOption{Interpretation: vtBytes, Type: tcaPeditKeysEx | nlaFNnested, Data: keysExData})
+
+	return marshalAttributes(options)
+}
+
+func unmarshalPedit(data []byte, info *Pedit) error {
+	ad, err := netlink.NewAttributeDecoder(data)
+	if err != nil {
+		return err
+	}
+	var multiError error
+	for ad.Next() {
+		switch ad.Type() {
+		case tcaPeditParmsEx, tcaPeditParms:
+			payload := ad.Bytes()
+			if len(payload) < 24 {
+				return fmt.Errorf("pedit parms too short: %d", len(payload))
+			}
+			sel := PeditSel{}
+			err = unmarshalStruct(payload[:24], &sel)
+			multiError = concatError(multiError, err)
+			info.Sel = sel
+			offset := 24
+			for i := uint8(0); i < sel.NKeys && offset+24 <= len(payload); i++ {
+				key := PeditKey{}
+				err = unmarshalStruct(payload[offset:offset+24], &key)
+				multiError = concatError(multiError, err)
+				info.Keys = append(info.Keys, key)
+				offset += 24
+			}
+		case tcaPeditTm:
+			tcft := &Tcft{}
+			err = unmarshalStruct(ad.Bytes(), tcft)
+			multiError = concatError(multiError, err)
+			info.Tm = tcft
+		case tcaPeditKeysEx, tcaPeditPad:
+			// The extended key data is only needed by callers that inspect raw netlink attrs.
+		default:
+			return fmt.Errorf("unmarshalPedit()\t%d\n\t%v", ad.Type(), ad.Bytes())
+		}
+	}
+	return concatError(multiError, ad.Err())
+}

--- a/m_pedit_test.go
+++ b/m_pedit_test.go
@@ -19,8 +19,8 @@ func TestPedit(t *testing.T) {
 			Keys:   []PeditKey{{Val: 0xc0a80101, Off: 12}},
 			KeysEx: []PeditKeyEx{{HeaderType: PeditHeaderTypeIP4, Cmd: PeditCmdSet}},
 		}},
-		"invalidArgument":    {val: Pedit{Tm: &Tcft{Install: 1}}, err1: ErrNoArgAlter},
-		"keyLengthMismatch":  {val: Pedit{Keys: []PeditKey{{Val: 1}}, KeysEx: []PeditKeyEx{}}, err1: errors.New("pedit keys and extended keys length mismatch")},
+		"invalidArgument":   {val: Pedit{Tm: &Tcft{Install: 1}}, err1: ErrNoArgAlter},
+		"keyLengthMismatch": {val: Pedit{Keys: []PeditKey{{Val: 1}}, KeysEx: []PeditKeyEx{}}, err1: errors.New("pedit keys and extended keys length mismatch")},
 	}
 
 	for name, testcase := range tests {

--- a/m_pedit_test.go
+++ b/m_pedit_test.go
@@ -1,0 +1,201 @@
+package tc
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestPedit(t *testing.T) {
+	tests := map[string]struct {
+		val  Pedit
+		err1 error
+		err2 error
+	}{
+		"simple": {val: Pedit{
+			Sel:    PeditSel{Action: 1},
+			Keys:   []PeditKey{{Val: 0xc0a80101, Off: 12}},
+			KeysEx: []PeditKeyEx{{HeaderType: PeditHeaderTypeIP4, Cmd: PeditCmdSet}},
+		}},
+		"invalidArgument":    {val: Pedit{Tm: &Tcft{Install: 1}}, err1: ErrNoArgAlter},
+		"keyLengthMismatch":  {val: Pedit{Keys: []PeditKey{{Val: 1}}, KeysEx: []PeditKeyEx{}}, err1: errors.New("pedit keys and extended keys length mismatch")},
+	}
+
+	for name, testcase := range tests {
+		t.Run(name, func(t *testing.T) {
+			data, err1 := marshalPedit(&testcase.val)
+			if err1 != nil {
+				if testcase.err1 != nil {
+					return
+				}
+				t.Fatalf("Unexpected error: %v", err1)
+			}
+			newData := injectAttribute(t, data, []byte{}, tcaPeditPad)
+			val := Pedit{}
+			err2 := unmarshalPedit(newData, &val)
+			if err2 != nil {
+				if testcase.err2 != nil {
+					return
+				}
+				t.Fatalf("Unexpected error: %v", err2)
+			}
+			// marshalPedit normalizes NKeys from len(Keys); reflect that in expected value.
+			testcase.val.Sel.NKeys = uint8(len(testcase.val.Keys))
+			if diff := cmp.Diff(val.Sel, testcase.val.Sel); diff != "" {
+				t.Fatalf("PeditSel mismatch (want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(val.Keys, testcase.val.Keys); diff != "" {
+				t.Fatalf("PeditKeys mismatch (want +got):\n%s", diff)
+			}
+		})
+	}
+
+	t.Run("nil", func(t *testing.T) {
+		_, err := marshalPedit(nil)
+		if !errors.Is(err, ErrNoArg) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("unmarshalPedit()", func(t *testing.T) {
+		err := unmarshalPedit([]byte{0x0}, nil)
+		if err == nil {
+			t.Fatalf("expected error but got none")
+		}
+	})
+}
+
+func TestPeditHelpers(t *testing.T) {
+	t.Run("SetIPv4Src", func(t *testing.T) {
+		p := &Pedit{}
+		ip := net.ParseIP("192.168.1.1")
+		p.SetIPv4Src(ip)
+		if len(p.Keys) != 1 || len(p.KeysEx) != 1 {
+			t.Fatalf("expected 1 key, got %d", len(p.Keys))
+		}
+		if p.KeysEx[0].HeaderType != PeditHeaderTypeIP4 {
+			t.Fatalf("expected IP4 header type, got %v", p.KeysEx[0].HeaderType)
+		}
+		if p.KeysEx[0].Cmd != PeditCmdSet {
+			t.Fatalf("expected Set cmd, got %v", p.KeysEx[0].Cmd)
+		}
+		if p.Keys[0].Off != 12 {
+			t.Fatalf("expected offset 12 (src IP), got %d", p.Keys[0].Off)
+		}
+	})
+
+	t.Run("SetIPv4Dst", func(t *testing.T) {
+		p := &Pedit{}
+		ip := net.ParseIP("10.0.0.1")
+		p.SetIPv4Dst(ip)
+		if len(p.Keys) != 1 {
+			t.Fatalf("expected 1 key, got %d", len(p.Keys))
+		}
+		if p.Keys[0].Off != 16 {
+			t.Fatalf("expected offset 16 (dst IP), got %d", p.Keys[0].Off)
+		}
+	})
+
+	t.Run("SetIPv4Src_nonIPv4", func(t *testing.T) {
+		p := &Pedit{}
+		p.SetIPv4Src(net.ParseIP("::1"))
+		if len(p.Keys) != 0 {
+			t.Fatalf("expected no keys for IPv6 address, got %d", len(p.Keys))
+		}
+	})
+
+	t.Run("SetUDPSrc", func(t *testing.T) {
+		p := &Pedit{}
+		p.SetUDPSrc(8080)
+		if len(p.Keys) != 1 {
+			t.Fatalf("expected 1 key, got %d", len(p.Keys))
+		}
+		if p.KeysEx[0].HeaderType != PeditHeaderTypeUDP {
+			t.Fatalf("expected UDP header type, got %v", p.KeysEx[0].HeaderType)
+		}
+	})
+
+	t.Run("SetUDPDst", func(t *testing.T) {
+		p := &Pedit{}
+		p.SetUDPDst(443)
+		if len(p.Keys) != 1 {
+			t.Fatalf("expected 1 key, got %d", len(p.Keys))
+		}
+		if p.KeysEx[0].HeaderType != PeditHeaderTypeUDP {
+			t.Fatalf("expected UDP header type, got %v", p.KeysEx[0].HeaderType)
+		}
+	})
+
+	t.Run("SetSrcPort_TCP", func(t *testing.T) {
+		p := &Pedit{}
+		p.SetSrcPort(1234, peditIPProtoTCP)
+		if len(p.Keys) != 1 {
+			t.Fatalf("expected 1 key, got %d", len(p.Keys))
+		}
+		if p.KeysEx[0].HeaderType != PeditHeaderTypeTCP {
+			t.Fatalf("expected TCP header type, got %v", p.KeysEx[0].HeaderType)
+		}
+	})
+
+	t.Run("SetSrcPort_unknownProtocol", func(t *testing.T) {
+		p := &Pedit{}
+		p.SetSrcPort(1234, 253)
+		if len(p.Keys) != 0 {
+			t.Fatalf("expected no keys for unknown protocol, got %d", len(p.Keys))
+		}
+	})
+
+	t.Run("SetEthDst", func(t *testing.T) {
+		p := &Pedit{}
+		mac, _ := net.ParseMAC("aa:bb:cc:dd:ee:ff")
+		p.SetEthDst(mac)
+		if len(p.Keys) != 2 {
+			t.Fatalf("expected 2 keys for MAC dst, got %d", len(p.Keys))
+		}
+		if p.KeysEx[0].HeaderType != PeditHeaderTypeEth {
+			t.Fatalf("expected Eth header type, got %v", p.KeysEx[0].HeaderType)
+		}
+	})
+
+	t.Run("SetEthSrc", func(t *testing.T) {
+		p := &Pedit{}
+		mac, _ := net.ParseMAC("11:22:33:44:55:66")
+		p.SetEthSrc(mac)
+		if len(p.Keys) != 2 {
+			t.Fatalf("expected 2 keys for MAC src, got %d", len(p.Keys))
+		}
+	})
+
+	t.Run("SetEthDst_shortMAC", func(t *testing.T) {
+		p := &Pedit{}
+		p.SetEthDst(net.HardwareAddr{0xaa, 0xbb})
+		if len(p.Keys) != 0 {
+			t.Fatalf("expected no keys for short MAC, got %d", len(p.Keys))
+		}
+	})
+
+	t.Run("AddIPv4TTL", func(t *testing.T) {
+		p := &Pedit{}
+		p.AddIPv4TTL(1)
+		if len(p.Keys) != 1 {
+			t.Fatalf("expected 1 key, got %d", len(p.Keys))
+		}
+		if p.KeysEx[0].Cmd != PeditCmdAdd {
+			t.Fatalf("expected Add cmd, got %v", p.KeysEx[0].Cmd)
+		}
+		if p.Keys[0].Off != 8 {
+			t.Fatalf("expected offset 8 (TTL), got %d", p.Keys[0].Off)
+		}
+	})
+
+	t.Run("NKeys_tracked", func(t *testing.T) {
+		p := &Pedit{}
+		p.SetIPv4Src(net.ParseIP("1.2.3.4"))
+		p.SetIPv4Dst(net.ParseIP("5.6.7.8"))
+		if p.Sel.NKeys != 2 {
+			t.Fatalf("expected NKeys=2, got %d", p.Sel.NKeys)
+		}
+	})
+}


### PR DESCRIPTION
### Problem
Working with the tc pedit action currently requires callers to manually
compute byte offsets, masks, and shifts for each packet field they want
to rewrite. This is error-prone and requires deep knowledge of packet
header layouts.

### Changes
Add full support for the pedit action, including:

- Core types: Pedit, PeditSel, PeditKey, PeditKeyEx
- PeditHeaderType and PeditCmd enums for extended key attributes
- marshal/unmarshal for the pedit netlink message format
- Wire pedit into the Action struct and kind-dispatch switch so it can be used alongside other actions

High-level helpers that abstract raw byte offset calculations:

- SetIPv4Src / SetIPv4Dst - rewrite IPv4 source/destination addresses
- SetEthSrc / SetEthDst - rewrite Ethernet MAC addresses
- SetSrcPort / SetDstPort / SetUDPSrc / SetUDPDst - rewrite L4 ports
- AddIPv4TTL - increment or decrement the IPv4 TTL field

### Sample TC Rule

```
tc filter add dev net0 ingress prio 1 handle 101 chain 0 proto ip flower \
  ip_flags nofrag ip_proto udp \
  src_ip 192.0.2.10/32 src_port 1111 \
  dst_ip 192.0.2.20/32 dst_port 2222 \
  action pedit ex \
    munge ip  src   set 10.0.0.1  \
    munge ip  dst   set 10.0.0.2  \
    munge udp sport set 10000     \
    munge udp dport set 20000     \
    munge ip  ttl   add 255       \
  pipe \
  action pedit ex \
    munge eth src set aa:bb:cc:dd:ee:01 \
    munge eth dst set aa:bb:cc:dd:ee:02 \
  pipe \
  action csum iph and udp pipe \
  action mirred egress redirect dev net1
```

The helpers map directly to munge clauses — each call sets the correct offset, mask, and value internally:

```go
var ipRW tc.Pedit
ipRW.SetIPv4Src(net.ParseIP("10.0.0.1")) // munge ip src set
ipRW.SetIPv4Dst(net.ParseIP("10.0.0.2")) // munge ip dst set
```

### Why
These helpers cover the most common stateless packet rewriting use cases,
following the same pattern established by other action types in this library.
Callers can now use p.SetIPv4Src(ip) instead of constructing raw
PeditKey structs with hardcoded offsets.